### PR TITLE
Add networkId param to send links to identify network of the payment

### DIFF
--- a/src/components/sendCard.js
+++ b/src/components/sendCard.js
@@ -383,7 +383,8 @@ class PayCard extends Component {
       type: "PT_LINK",
       recipient: emptyAddress,
       meta: {
-        secret: connext.generateSecret()
+        secret: connext.generateSecret(),
+        ethChainId: connext.opts.ethChainId
       }
     };
 
@@ -604,12 +605,13 @@ class PayCard extends Component {
         // automatically route to redeem card
         const secret = paymentVal.payments[0].meta.secret;
         const amountToken = paymentVal.payments[0].amountToken;
+        const ethChainId = paymentVal.payments[0].meta.ethChainId;
         this.props.history.push({
           pathname: "/redeem",
           // TODO: add wei
           search: `?secret=${secret}&amountToken=${
-            Web3.utils.fromWei(amountToken, "ether")
-          }`,
+            Web3.utils.fromWei(amountToken, "ether")}&networkId=${
+            ethChainId}`,
           state: { isConfirm: true, secret, amountToken }
         });
       } else {


### PR DESCRIPTION
<!--- Make sure your title is descriptive -->
<!--- If you have any questions, don't hesitate to reach out to us on Discord! -->

## The Problem
<!--- Why is this change required? What problem does it solve? Bug fix or new feature? -->
Currently, when a user hits the redeemCard path via a link or QR code, they will either connect to whatever network they on last or if a first time user they will connect to the default network. But what if I'm creating a send link for DAI on Rinkeby and the user defaults to mainnet? Or if the user was last on Rinkeby and is wondering why my mainnet DAI link isn't showing up? They will be feeling a bit sad, a bit abandoned, and a bit filled with rage at us devs. We don't want to do that to our users.
<!--- If it fixes an open issue, please link to the issue here. -->

## The Solution
<!--- Describe the changes you made in detail -->
- I changed the link generated by the sendCard to include a `networkId` param, retrieved from `connext.opts` at the time of link creation.
- I changed redeemCard to include this param in its printed link and QR code
- I changed redeemCard to set the user's network to the same network as the payment
<!--- Describe any backwards-incompatible changes you might have introduced & their implications -->
I don't think there are any, because if there's no `networkId` param, nothing happens.
<!--- Which parts of this PR should be given extra attention during review (eg if fragile or hard to test) -->
<!--- Leave comments on important parts of the source diff to clarify above prompts -->

## Checklist:
<!--- Go over each of the following points & put an `x` in all the boxes that apply. -->
- [ ] I have incremented the version in the project root's package.json
- [ ] The commit that increments the version includes the new version number in it's commit message
- [x] My code follows the code style of this project.
- [ ] This code has passed all CI tests & has been deployed successfully to staging.
- [ ] I have verified that, following above, the staging site reflected these changes and worked as expected.
- [ ] I have described any backwards-incompatibility implications above.
- [ ] I have highlighted which parts of the code should be reviewed most carefully.
- [ ] If my change requires a change to the documentation, I have updated the documentation accordingly.

<!--- For each unchecked box above, briefly mention why it's unchecked -->
