### PR TITLE
Only update sendCard amount if non-0 number in scan

### DIFF
--- a/src/components/sendCard.js
+++ b/src/components/sendCard.js
@@ -304,7 +304,7 @@ class PayCard extends Component {
       let temp = data[1].split("&");
       let amount = temp[0].split("=")[1];
       let recipient = temp[1].split("=")[1];
-      if (Number(amount)) this.updatePaymentHandler(amount);
+      if (Number(amount) > 0) this.updatePaymentHandler(amount);
       this.updateRecipientHandler(recipient);
     } else {
       this.updateRecipientHandler(scanResult);

--- a/src/components/sendCard.js
+++ b/src/components/sendCard.js
@@ -304,7 +304,7 @@ class PayCard extends Component {
       let temp = data[1].split("&");
       let amount = temp[0].split("=")[1];
       let recipient = temp[1].split("=")[1];
-      this.updatePaymentHandler(amount);
+      if (Number(amount)) this.updatePaymentHandler(amount);
       this.updateRecipientHandler(recipient);
     } else {
       this.updateRecipientHandler(scanResult);


### PR DESCRIPTION
<!--- Make sure your title is descriptive -->
<!--- If you have any questions, don't hesitate to reach out to us on Discord! -->

## The Problem
<!--- Why is this change required? What problem does it solve? Bug fix or new feature? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Quick 1-liner to handle a frustrated UX case from our events: if the receiver has not entered an amount, there is no reason for the sender's input amount to revert to 0 when scanning the receiver's QR code.

## The Solution
<!--- Describe the changes you made in detail -->
<!--- Describe any backwards-incompatible changes you might have introduced & their implications -->
<!--- Which parts of this PR should be given extra attention during review (eg if fragile or hard to test) -->
<!--- Leave comments on important parts of the source diff to clarify above prompts -->

## Checklist:
<!--- Go over each of the following points & put an `x` in all the boxes that apply. -->
- [ ] I have incremented the version in the project root's package.json
- [ ] The commit that increments the version includes the new version number in it's commit message
- [ ] My code follows the code style of this project.
- [ ] This code has passed all CI tests & has been deployed successfully to staging.
- [ ] I have verified that, following above, the staging site reflected these changes and worked as expected.
- [ ] I have described any backwards-incompatibility implications above.
- [ ] I have highlighted which parts of the code should be reviewed most carefully.
- [ ] If my change requires a change to the documentation, I have updated the documentation accordingly.

<!--- For each unchecked box above, briefly mention why it's unchecked -->
