### PR TITLE
allow user to delete amount from receiveCard without error

### DIFF
--- a/src/components/receiveCard.js
+++ b/src/components/receiveCard.js
@@ -78,7 +78,6 @@ class ReceiveCard extends Component {
     const decimal = (
       value.startsWith('.') ? value.substr(1) : value.split('.')[1]
     )
-
     let error = null
     let tokenVal = value
     if (decimal && decimal.length > 18) {
@@ -87,7 +86,7 @@ class ReceiveCard extends Component {
     }    
     this.setState({
       qrUrl: this.generateQrUrl(value),
-      amountToken: Web3.utils.toWei(tokenVal, "ether"),
+      amountToken: tokenVal ? Web3.utils.toWei(tokenVal, "ether") : null,
       displayValue: value,
       error,
     });


### PR DESCRIPTION
<!--- Make sure your title is descriptive -->
<!--- If you have any questions, don't hesitate to reach out to us on Discord! -->

## The Problem
<!--- Why is this change required? What problem does it solve? Bug fix or new feature? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Simple 1-liner UX fix. Currently, user cannot delete the amount in their receive card, because `amountToken` evaluates to an empty string (should be null).

## The Solution
<!--- Describe the changes you made in detail -->
<!--- Describe any backwards-incompatible changes you might have introduced & their implications -->
<!--- Which parts of this PR should be given extra attention during review (eg if fragile or hard to test) -->
<!--- Leave comments on important parts of the source diff to clarify above prompts -->

## Checklist:
<!--- Go over each of the following points & put an `x` in all the boxes that apply. -->
- [ ] I have incremented the version in the project root's package.json
- [ ] The commit that increments the version includes the new version number in it's commit message
- [ ] My code follows the code style of this project.
- [ ] This code has passed all CI tests & has been deployed successfully to staging.
- [ ] I have verified that, following above, the staging site reflected these changes and worked as expected.
- [ ] I have described any backwards-incompatibility implications above.
- [ ] I have highlighted which parts of the code should be reviewed most carefully.
- [ ] If my change requires a change to the documentation, I have updated the documentation accordingly.

<!--- For each unchecked box above, briefly mention why it's unchecked -->
