### PR TITLE
set public url in app construtor

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -116,6 +116,9 @@ class App extends React.Component {
     };
 
     this.networkHandler = this.networkHandler.bind(this);
+
+    // set public url
+    publicUrl = window.location.origin.toLowerCase();
   }
 
   // ************************************************* //
@@ -125,9 +128,6 @@ class App extends React.Component {
   async componentDidMount() {
     // on mount, check if you need to refund by removing maxBalance
     localStorage.removeItem("refunding");
-
-    // set public url
-    publicUrl = window.location.origin.toLowerCase();
 
     // Get mnemonic and rpc type
     let mnemonic = localStorage.getItem("mnemonic");


### PR DESCRIPTION
<!--- Make sure your title is descriptive -->
<!--- If you have any questions, don't hesitate to reach out to us on Discord! -->

## The Problem
<!--- Why is this change required? What problem does it solve? Bug fix or new feature? -->
<!--- If it fixes an open issue, please link to the issue here. -->
`publicUrl` is not set when `render()` is called for the first time, so a user landing on `/receive` does not get a fully-formed URL in their link/QRcode (there is no domain). To fix, we just set the publicUrl in the `App.js` constructor instead of `componentDidMount()`

## The Solution
<!--- Describe the changes you made in detail -->
<!--- Describe any backwards-incompatible changes you might have introduced & their implications -->
<!--- Which parts of this PR should be given extra attention during review (eg if fragile or hard to test) -->
<!--- Leave comments on important parts of the source diff to clarify above prompts -->

## Checklist:
<!--- Go over each of the following points & put an `x` in all the boxes that apply. -->
- [ ] I have incremented the version in the project root's package.json
- [ ] The commit that increments the version includes the new version number in it's commit message
- [ ] My code follows the code style of this project.
- [ ] This code has passed all CI tests & has been deployed successfully to staging.
- [ ] I have verified that, following above, the staging site reflected these changes and worked as expected.
- [ ] I have described any backwards-incompatibility implications above.
- [ ] I have highlighted which parts of the code should be reviewed most carefully.
- [ ] If my change requires a change to the documentation, I have updated the documentation accordingly.

<!--- For each unchecked box above, briefly mention why it's unchecked -->
